### PR TITLE
Add BASE_URL environment variable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # FoodShare-Nairobi
-A web application connecting food donors to verified charitable institutions to facilitate donations
+A web application connecting food donors to verified charitable institutions to facilitate donations.
+
+## Configuration
+
+Set the `BASE_URL` environment variable to the public URL of your server. This value is used when generating password reset links and defaults to `http://localhost:3000` if not specified.

--- a/backend/Routes/auth.js
+++ b/backend/Routes/auth.js
@@ -5,6 +5,9 @@ const bcrypt = require('bcrypt');
 const crypto = require('crypto');
 const nodemailer = require('nodemailer');
 
+// Base URL for password reset links
+const baseUrl = process.env.BASE_URL || 'http://localhost:3000';
+
 //  Direct DB connection
 const db = mysql.createConnection({
     host: '25.18.191.107',
@@ -40,7 +43,7 @@ router.post('/forgot-password', (req, res) => {
       }
     });
 
-    const resetLink = `http://localhost:3000/reset-password.html?token=${token}&role=${role}`;
+    const resetLink = `${baseUrl}/reset-password.html?token=${token}&role=${role}`;
     const mailOptions = {
       from: 'vicbiznetworks@gmail.com',
       to: email,


### PR DESCRIPTION
## Summary
- allow configuring reset link domain via `BASE_URL`
- document `BASE_URL` in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6857f891ba5c832e9c7d6d92faf6d627