### PR TITLE
Use environment variables for secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+DB_HOST=localhost
+DB_USER=your_db_user
+DB_PASSWORD=your_db_password
+DB_NAME=foodshare_db
+DB_PORT=3306
+EMAIL_USER=your_gmail_account
+EMAIL_PASSWORD=your_gmail_app_password
+BASE_URL=http://localhost:3000

--- a/backend/.env
+++ b/backend/.env
@@ -1,7 +1,0 @@
-const db = mysql.createConnection({
-  host: '25.18.191.107',
-  user: 'Dexter',
-  password: 'F00dshare123',
-  database: 'foodshare_db'
-  port: 3306
-});

--- a/backend/Database/db.js
+++ b/backend/Database/db.js
@@ -1,9 +1,9 @@
 const pool = require('mysql2/promise').createPool({
-  host: '25.18.191.107',
-  user: 'Dexter',
-  password: 'F00dshare123',
-  database: 'foodshare_db',
-  port: 3306,
+  host: process.env.DB_HOST,
+  user: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_NAME,
+  port: process.env.DB_PORT || 3306,
   waitForConnections: true,
   connectionLimit: 10,
   queueLimit: 0

--- a/backend/Routes/auth.js
+++ b/backend/Routes/auth.js
@@ -10,11 +10,11 @@ const baseUrl = process.env.BASE_URL || 'http://localhost:3000';
 
 //  Direct DB connection
 const db = mysql.createConnection({
-    host: '25.18.191.107',
-    user: 'Dexter',
-    password: 'F00dshare123',
-    database: 'foodshare_db',
-    port: 3306
+    host: process.env.DB_HOST,
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME,
+    port: process.env.DB_PORT || 3306
 });
 
 db.connect((err) => {
@@ -38,14 +38,14 @@ router.post('/forgot-password', (req, res) => {
     const transporter = nodemailer.createTransport({
       service: 'gmail',
       auth: {
-        user: 'vicbiznetworks@gmail.com', // use your Gmail
-        pass: 'khwi oxlj pycg lsev'     // generated Gmail app password
+        user: process.env.EMAIL_USER,
+        pass: process.env.EMAIL_PASSWORD
       }
     });
 
     const resetLink = `${baseUrl}/reset-password.html?token=${token}&role=${role}`;
     const mailOptions = {
-      from: 'vicbiznetworks@gmail.com',
+      from: process.env.EMAIL_USER,
       to: email,
       subject: 'Password Reset - FoodShare',
       html: `<p>You requested a password reset. 

--- a/backend/Routes/emailVerification.js
+++ b/backend/Routes/emailVerification.js
@@ -16,10 +16,13 @@ router.post('/send-otp', async (req, res) => {
   // Send email (configure your SMTP)
   const transporter = nodemailer.createTransport({
     service: 'gmail',
-    auth: { user: 'dexter.kimathi@strathmore.edu', pass: 'lbmx knru grzy jmrb' }
+    auth: {
+      user: process.env.EMAIL_USER,
+      pass: process.env.EMAIL_PASSWORD
+    }
   });
   await transporter.sendMail({
-    from: 'FoodShare <dexter.kimathi@strathmore.edu>',
+    from: `FoodShare <${process.env.EMAIL_USER}>`,
     to: email,
     subject: 'Your FoodShare Email Verification OTP',
     html: `<p>Your OTP for FoodShare email verification is: <b>${otp}</b></p><p>This code is valid for 10 minutes.</p>`

--- a/backend/Utils/charityApprovalEmail.js
+++ b/backend/Utils/charityApprovalEmail.js
@@ -7,17 +7,17 @@ const nodemailer = require('nodemailer');
  * @returns {Promise<void>}
  */
 async function sendCharityApprovalEmail(toEmail, charityName) {
-  // Configure transporter with vicbiznetworks@gmail.com
+  // Configure transporter using environment credentials
   const transporter = nodemailer.createTransport({
     service: 'gmail',
     auth: {
-      user: 'vicbiznetworks@gmail.com',
-      pass: 'khwi oxlj pycg lsev' // Use your Gmail app password
+      user: process.env.EMAIL_USER,
+      pass: process.env.EMAIL_PASSWORD
     }
   });
 
   const mailOptions = {
-    from: 'vicbiznetworks@gmail.com',
+    from: process.env.EMAIL_USER,
     to: toEmail,
     subject: 'Your Charity Has Been Approved - FoodShare Nairobi',
     html: `<p>Dear <b>${charityName}</b>,</p>

--- a/backend/Utils/foodNeedConfirmationEmail.js
+++ b/backend/Utils/foodNeedConfirmationEmail.js
@@ -11,13 +11,13 @@ async function sendFoodNeedConfirmationEmail(toEmail, orgName, foodNeed) {
   const transporter = nodemailer.createTransport({
     service: 'gmail',
     auth: {
-      user: 'vicbiznetworks@gmail.com',
-      pass: 'khwi oxlj pycg lsev'
+      user: process.env.EMAIL_USER,
+      pass: process.env.EMAIL_PASSWORD
     }
   });
 
   const mailOptions = {
-    from: 'vicbiznetworks@gmail.com',
+    from: process.env.EMAIL_USER,
     to: toEmail,
     subject: 'Your Food Need Has Been Submitted - FoodShare Nairobi',
     html: `<p>Dear <b>${orgName}</b>,</p>

--- a/backend/Utils/foodNeedPledgeEmail.js
+++ b/backend/Utils/foodNeedPledgeEmail.js
@@ -3,8 +3,8 @@ const nodemailer = require('nodemailer');
 const transporter = nodemailer.createTransport({
   service: 'gmail',
   auth: {
-    user: 'vicbiznetworks@gmail.com',
-    pass: process.env.EMAIL_PASSWORD || 'khwi oxlj pycg lsev' // Use env var in production
+    user: process.env.EMAIL_USER,
+    pass: process.env.EMAIL_PASSWORD
   }
 });
 
@@ -30,7 +30,7 @@ async function sendFoodNeedPledgeEmail(toEmail, charityName, pledge) {
     <p><i>This is an automated message from FoodShare Nairobi.</i></p>
   `;
   await transporter.sendMail({
-    from: 'vicbiznetworks@gmail.com',
+    from: process.env.EMAIL_USER,
     to: toEmail,
     subject,
     html: body

--- a/backend/db.js
+++ b/backend/db.js
@@ -2,11 +2,11 @@
 const mysql = require('mysql2/promise');
 
 const pool = mysql.createPool({
-  host: '25.18.191.107',
-  user: 'Dexter',
-  password: 'F00dshare123',
-  database: 'foodshare_db',
-  port: 3306,
+  host: process.env.DB_HOST,
+  user: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_NAME,
+  port: process.env.DB_PORT || 3306,
   waitForConnections: true,
   connectionLimit: 10,
   queueLimit: 0

--- a/backend/server.js
+++ b/backend/server.js
@@ -34,11 +34,11 @@ const upload = multer({ storage });
 
 // DB Connection
 const pool = mysql.createPool({
-  host: '25.18.191.107',
-  user: 'Dexter',
-  password: 'F00dshare123',
-  database: 'foodshare_db',
-  port: 3306,
+  host: process.env.DB_HOST,
+  user: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_NAME,
+  port: process.env.DB_PORT || 3306,
   waitForConnections: true,
   connectionLimit: 10,
   queueLimit: 0


### PR DESCRIPTION
## Summary
- provide `.env.example` with placeholders for DB and Gmail credentials
- load MySQL config from environment variables
- send emails with credentials from environment variables
- remove plaintext `.env` file

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68892cba7e68832ebe7f31cec0dccde9